### PR TITLE
🐛 Fix: GenericTable props 경고 메시지 수정 #41

### DIFF
--- a/src/main/reactfront/src/components/genericTable/GenericTable.styles.ts
+++ b/src/main/reactfront/src/components/genericTable/GenericTable.styles.ts
@@ -45,7 +45,7 @@ export const TableRow = styled.tr`
   }
 `;
 
-export const TableData = styled.td<{ Width?: number }>`
+export const TableData = styled.td<{ $Width?: number }>`
   padding: 10px 5px;
   cursor: pointer;
   font-size: 14px;
@@ -57,14 +57,14 @@ export const TableData = styled.td<{ Width?: number }>`
   text-align: center;
   border: 1px solid #e4e9ea;
   position: relative;
-  max-width: ${(props) => (props.Width ? `${props.Width}px` : 'none')};
+  max-width: ${(props) => (props.$Width ? `${props.$Width}px` : 'none')};
   &:first-child {
     padding: 12px 5px;
     min-width: 50px;
   }
 `;
 
-export const Image = styled.div<{ backgroundImage: string }>`
+export const Image = styled.div<{ $backgroundImage: string }>`
   position: absolute;
   left: 30px;
   top: 50%;
@@ -72,7 +72,7 @@ export const Image = styled.div<{ backgroundImage: string }>`
   width: 36px;
   height: 36px;
   border-radius: 50%;
-  background-image: url(${(props) => props.backgroundImage});
+  background-image: url(${(props) => props.$backgroundImage});
   background-position: center;
   background-size: cover;
 `;
@@ -99,12 +99,12 @@ export const Category = styled.span`
 `;
 
 interface StatusIndicatorProps {
-  color: string;
-  backgroundColor: string;
+  $color: string;
+  $backgroundColor: string;
 }
 
 export const StatusIndicator = styled.span<StatusIndicatorProps>`
-  color: ${(props) => props.color};
+  color: ${(props) => props.$color};
   text-align: left;
   &:before {
     content: '';
@@ -113,6 +113,6 @@ export const StatusIndicator = styled.span<StatusIndicatorProps>`
     display: inline-block;
     margin-right: 7px;
     border-radius: 50%;
-    background-color: ${(props) => props.backgroundColor};
+    background-color: ${(props) => props.$backgroundColor};
   }
 `;


### PR DESCRIPTION
## Part
- [x] Front-End
- [ ] Back-End

## 요약
GenericTable에서 styled-components를 사용할 때, DOM 요소에 알 수 없는 props가 전달될 때 경고 메시지가 발생하는 부분을 수정함

## 내용
GenericTable props 경고 메시지 수정을 위해
- props 이름 앞에 $를 붙여 transient props로 변경
- styled-components가 해당 props를 DOM 요소에 전달하지 않도록 설정

## PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 UI/스타일 파일 추가/수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경 등)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 관련
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

## 기타

close #41 
