### PR TITLE
🐛 Fix: React Router 경로 문제로 빈 화면이 발생하는 이슈 수정 #69

### DIFF
--- a/src/main/java/com/spring/myapp/config/WebConfig.java
+++ b/src/main/java/com/spring/myapp/config/WebConfig.java
@@ -8,7 +8,8 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 public class WebConfig implements WebMvcConfigurer {
 	@Override
 	public void addViewControllers(ViewControllerRegistry registry) {
-		registry.addViewController("/{path:^(?!index\\.html$).*}/**")
+
+		registry.addViewController("/{spring:[^.]*}")
 			.setViewName("forward:/index.html");
 	}
 }


### PR DESCRIPTION
## Part
- [ ] Front-End
- [x] Back-End

## 요약
React Router 경로 문제로 빈 화면이 발생하는 이슈 수정

## 내용
Spring Boot와 React를 통합하여 사용 중, 브라우저에서 경로를 변경할 때 React Router에 의해 빈 화면이 표시되는 문제가 발생했습니다. 이 문제는 WebConfig 설정이 올바르게 작동하지 않아서 발생했습니다.

- WebConfig 클래스에서 모든 경로를 index.html로 포워딩하는 방식을 단순화하여 해결

## PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 UI/스타일 파일 추가/수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경 등)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 관련
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

## 기타

close #69 
