### PR TITLE
🐛 Fix : 정보글 수정 관련 에러 해결 #239

### DIFF
--- a/src/main/java/com/spring/myapp/informationBoard/controller/InfoBoardController.java
+++ b/src/main/java/com/spring/myapp/informationBoard/controller/InfoBoardController.java
@@ -95,7 +95,7 @@ public class InfoBoardController {
 	@PutMapping("/info/update/{infoId}") // 새 정보글 수정
 	public ResponseEntity<?> updateInfoPost(@RequestPart("information") String informationStr,
 		@RequestPart(value = "file", required = false) MultipartFile file,
-		@PathVariable(value = "existingImageUrl", required = false) String existingImageUrl,
+		@RequestPart(value = "existingImageUrl", required = false) String existingImageUrl,
 		@PathVariable("infoId") Long infoId) throws IOException {
 
 		Information info = objectMapper.readValue(informationStr, Information.class); // json으로 받은 데이터 객체화

--- a/src/main/reactfront/src/pages/administrator/PostRegisterPage.tsx
+++ b/src/main/reactfront/src/pages/administrator/PostRegisterPage.tsx
@@ -130,8 +130,6 @@ const PostRegisterPage: React.FC = () => {
       userId: userId,
     };
 
-    console.log(infoData);
-
     const formData = new FormData();
     formData.append('information', JSON.stringify(infoData));
     // if (imageFile) {
@@ -143,6 +141,8 @@ const PostRegisterPage: React.FC = () => {
       formData.append('existingImageUrl', imageFile);
     }
 
+    console.log(imageFile);
+
     try {
       if (infoId !== undefined) {
         await axios.put(`/api/info/update/${infoId}`, formData, {
@@ -150,15 +150,17 @@ const PostRegisterPage: React.FC = () => {
             'Content-Type': 'multipart/form-data',
           },
         });
+        alert('등록되었습니다.');
+        navigate(`/info/${infoId}`);
       } else {
         await axios.post('/api/newInfo', formData, {
           headers: {
             'Content-Type': 'multipart/form-data',
           },
         });
+        alert('등록되었습니다.');
+        navigate('/info/search');
       }
-      alert('등록되었습니다.');
-      navigate('/info/search');
     } catch (error) {
       console.error('Error submitting form:', error);
     }
@@ -278,7 +280,11 @@ const PostRegisterPage: React.FC = () => {
               }}
             >
               <Link
-                to={infoId !== undefined ? '/info' : '/administrator/post-list'}
+                to={
+                  infoId !== undefined
+                    ? '/info/search'
+                    : '/administrator/post-list'
+                }
               >
                 <GenericButton
                   style={{


### PR DESCRIPTION
## Part
- [x] Front-End
- [x] Back-End

## 요약
정보글 수정 시 기존에 있던 썸네일 이미지 저장 관련 에러 해결

## 내용
- 정보글 수정 시 썸네일 이미지가 변경되지 않는다면 기존에 있던 썸네일 이미지를 다시 저장하는 과정에서 발생하는 에러 해결
- 수정 취소 시 리다이렉션 경로 수정 -> 게시판 목록으로 이동
- 수정 완료시 해당 글로 이동하도록 경로 변경

## PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 UI/스타일 파일 추가/수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경 등)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 관련
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

## 기타

close #239
